### PR TITLE
flag unlabeled PRs with wildcard label

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,53 @@ The supported options are:
 
 - `labels`: GitHub PR labels mapped to changelog section headers
 
+- `wildcardLabel`: A label to identify commits that don't have a GitHub PR label 
+  which matches a value in `labels`. (e.g. `unlabeled`) By default, this has no value. [Read more about this option](#wildcardlabel).
+
 - `ignoreCommitters`: List of committers to ignore (exact or partial match).
   Useful for example to ignore commits from bots.
 
 - `cacheDir`: Path to a GitHub API response cache to avoid throttling
   (e.g. `.changelog`)
+
+### wildcardLabel
+
+For some projects, it may be beneficial to list PRs in the changelog that don't 
+have a matching label defined in the configuration `labels`. Listing these PRs also allows you to review the changelog and identify any PRs that should be re-labeled on GitHub. For example, forgetting to label a breaking change.
+
+```json5
+{
+  // ...
+  "changelog": {
+    "wildcardLabel": "unlabeled"
+  }
+}
+```
+
+A default changlog heading of `:present: Additional updates` is set when a value for `wildcardLabel` is in the configuration.
+
+```md
+## Unreleased (2018-05-24)
+
+#### 🎁 Additional updates
+* [#514](https://github.com/my-org/my-repo/pull/514) Setting to mute video ([@diligent-developer](https://github.com/diligent-developer))
+```
+
+You can overwrite the default heading by including the `wildcardLabel` value in the configuration's `labels` object. For example:
+
+```json5
+{
+  // ...
+  "changelog": {
+    "labels": {
+      "feature": "New Feature",
+      "bug": "Bug Fix",
+      "unlabeled": "Unlabeled PRs"
+    },
+    "wildcardLabel": "unlabeled"
+  }
+}
+```
 
 
 License

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -207,13 +207,12 @@ export default class Changelog {
       const labels = commit.githubIssue.labels.map(label => label.name.toLowerCase());
 
       if (this.config.wildcardLabel) {
-        // check whether the commit has any of the labels from the learna.json config. 
+        // check whether the commit has any of the labels from the learna.json config.
         // If not, label this commit with the provided label
 
-        let foundLabel = Object.keys(this.config.labels)
-        .some(label => labels.indexOf(label.toLowerCase()) !== -1);
+        let foundLabel = Object.keys(this.config.labels).some(label => labels.indexOf(label.toLowerCase()) !== -1);
 
-       if (!foundLabel) {
+        if (!foundLabel) {
           labels.push(this.config.wildcardLabel);
         }
       }

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -206,6 +206,18 @@ export default class Changelog {
 
       const labels = commit.githubIssue.labels.map(label => label.name.toLowerCase());
 
+      if (this.config.wildcardLabel) {
+        // check whether the commit has any of the labels from the learna.json config. 
+        // If not, label this commit with the provided label
+
+        let foundLabel = Object.keys(this.config.labels)
+        .some(label => labels.indexOf(label.toLowerCase()) !== -1);
+
+       if (!foundLabel) {
+          labels.push(this.config.wildcardLabel);
+        }
+      }
+
       commit.categories = Object.keys(this.config.labels)
         .filter(label => labels.indexOf(label.toLowerCase()) !== -1)
         .map(label => this.config.labels[label]);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,7 +13,7 @@ export interface Configuration {
   cacheDir?: string;
   nextVersion: string | undefined;
   nextVersionFromMetadata?: boolean;
-  wildcardLabel? : string;
+  wildcardLabel?: string;
 }
 
 export interface ConfigLoaderOptions {
@@ -60,7 +60,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
   }
 
   if (wildcardLabel && !labels[wildcardLabel]) {
-    labels[wildcardLabel] = "️:present: Additional updates"
+    labels[wildcardLabel] = "️:present: Additional updates";
   }
 
   if (!ignoreCommitters) {
@@ -81,7 +81,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     labels,
     ignoreCommitters,
     cacheDir,
-    wildcardLabel
+    wildcardLabel,
   };
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,6 +13,7 @@ export interface Configuration {
   cacheDir?: string;
   nextVersion: string | undefined;
   nextVersionFromMetadata?: boolean;
+  wildcardLabel? : string;
 }
 
 export interface ConfigLoaderOptions {
@@ -31,7 +32,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
   let config = fromPackageConfig(rootPath) || fromLernaConfig(rootPath) || {};
 
   // Step 2: fill partial config with defaults
-  let { repo, nextVersion, labels, cacheDir, ignoreCommitters } = config;
+  let { repo, nextVersion, labels, cacheDir, ignoreCommitters, wildcardLabel } = config;
 
   if (!repo) {
     repo = findRepo(rootPath);
@@ -58,6 +59,10 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     };
   }
 
+  if (wildcardLabel && !labels[wildcardLabel]) {
+    labels[wildcardLabel] = "️:present: Additional updates"
+  }
+
   if (!ignoreCommitters) {
     ignoreCommitters = [
       "dependabot-bot",
@@ -76,6 +81,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     labels,
     ignoreCommitters,
     cacheDir,
+    wildcardLabel
   };
 }
 


### PR DESCRIPTION
## Purpose

Exploring how to use `lerna-changelog` to identify unlabeled PRs that we committed. Related issue: https://github.com/lerna/lerna-changelog/issues/74

### Result

Example from my testing:

```
## Unreleased (2019-05-04)

#### 🚀 Enhancement
* [#838](https://github.com/foo/bar/pull/838) Update search results layout ([@NathanPJF](https://github.com/nathanpjf))

#### ⚠️ Unlabeled
* [#903](https://github.com/foo/bar/pull/903) Unhide mute button ([@somePerson](https://github.com/somePerson))
* [#923](https://github.com/foo/bar/pull/923) Convert hardcoded values ([@somePerson](https://github.com/somePerson))
```


### Approach

Check all the labels on a commit, if none of them match the `labels` in the config file, this tool adds a label to the commit.  This makes sure that when `commit.categories` is built, the commit is included since it is now labeled.

A developer can use the existing `labels` config to decide what heading goes on it in the terminal output.

```json
  "changelog": {
    "labels": {
      "breaking change": "💥 Breaking Change",
      "enhancement": "🚀 Enhancement",
      "docs": "📝 Documentation",
      "bug fix": "🐛 Bug fixes",
      "unlabeled": "⚠️ Unlabeled"
    },
    "wildcardLabel": "unlabeled",
    "cacheDir": ".changelog"
  }
```

This `wildcardLabel` feature is optional because it means any commit to `master` that isn't using a label from the config's `labels` is going to get flagged. That's great if you want to make sure you review every PR in the terminal output, but might be annoying if you feel you are super diligent about labeling your PRs and don't need a reminder.

Pros:
* The value for `wildcardLabel` can match a real label being used by the development team and still get the desired result. In fact, it can add as a safeguard for times people forget to put this `unlabeled` label.

### Questions:
What do you do when `wildcardLabel` has a value, but no matching key in `unlabeled`?  Provide a default message?

In [`lerna-changelog` configuration](https://github.com/lerna/lerna-changelog#configuration), there is a default title for `nextVersion` of "Unreleased".  I could go with a default heading for unlabeled PRs, and if someone wants a specific heading, they just need to add it to the `labels` config.

**Decision**: I decided to provide a default in the `configuration.ts` so that a default heading is provided. The user can override this by providing a value for the same label in the `labels` property.